### PR TITLE
Pass along filter data to csv download

### DIFF
--- a/static/js/app/views/ListView.js
+++ b/static/js/app/views/ListView.js
@@ -46,7 +46,21 @@ var ListView = Backbone.View.extend({
     this.$('form')[0].reset();
   },
   downloadCSV: function downloadCSV (e) {
-    window.location = '/quotas.csv';
+    var data = {}, queryString;
+
+    if (this.filterData['since-date']) {
+      data['since'] = this.filterData['since-date'];
+    }
+
+    if (this.filterData['until-date']) {
+      data['until'] = this.filterData['until-date'];
+    }
+
+    queryString = Object.keys(data).map(function(k) {
+      return encodeURIComponent(k) + '=' + encodeURIComponent(data[k]);
+    }).join('&');
+
+    window.location = '/quotas.csv?' + queryString;
   }
 });
 


### PR DESCRIPTION
This PR makes sure to send any date filtering data along with the CSV download request. This has the nice effect of making sure that what a user downloads in the CSV matches what they currently see on the screen :)

Closes #33 and thereby #20.
