### PR TITLE
Hide quota GUID filter

### DIFF
--- a/static/js/app/templates/FormControlsView.html
+++ b/static/js/app/templates/FormControlsView.html
@@ -1,13 +1,15 @@
-<% window.f = filter %>
+<!--
 <div class="form-group">
   <label for="quota-selection">Quota</label>
   <select class="form-control" id="quota-selection" name="quota-selection">
-      <option value="">All</option> <!-- default -->
+      <option value="">All</option>
     <% _.each(collection, function(quota) { %>
       <option value="<%- quota.guid %>"><%- quota.name %></option>
     <% }); %>
   </select>
 </div>
+-->
+
 <div class="form-group">
   <% var sinceDate %>
   <% (filter['since-date']) ? sinceDate = filter['since-date'] : sinceDate = '' %>


### PR DESCRIPTION
Per #40 it was confusing to have the GUID filter (especially since it didn't work) for the current iteration of the app. I just put the relevant bit of the template inside of an HTML comment so that it is no longer visible to the user

To close #40 
