### PR TITLE
Fix CSV download bug

### DIFF
--- a/static/js/app/views/ListView.js
+++ b/static/js/app/views/ListView.js
@@ -17,6 +17,7 @@ var ListView = Backbone.View.extend({
   },
   initialize: function initialize () {
     this.listenTo(this.collection, 'sync', this.render);
+    this.filterData = {};
   },
   render: function render () {
     this.$el.html(listTemplateHtml);


### PR DESCRIPTION
The CSV download was not working if you didn't use the filter before attempting to download. This is because the `filterData` on the view object wasn't initialized so even key lookup was failing in `ListView.js#51`

@ramirezg can you take a look and see if it just works on your machine? If so, please deploy
