### PR TITLE
Force cost to only have two decimal places in view

### DIFF
--- a/static/js/app/views/ListItemView.js
+++ b/static/js/app/views/ListItemView.js
@@ -14,7 +14,9 @@ var ListItemView = Backbone.View.extend({
     this.render();
   },
   render: function render () {
-    var html = this.template(this.model.toJSON());
+    var quota = this.model.toJSON();
+    quota['cost'] = quota['cost'].toFixed(2);
+    var html = this.template(quota);
     this.$el.html(html);
   }
 });


### PR DESCRIPTION
Since we are using a cost algorithm that might result in floating numbers with more than two decimal places, it looks like we're charging fractions of cents (#37).

This forces the cost number in the JavaScript view to use `toFixed(2)` so that the dollar amounts look normal.
