### PR TITLE
add a basic code climate config and corresponding badge to the README

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,14 @@
+engines:
+  duplication:
+    enabled: false
+  fixme:
+    enabled: true
+  radon:
+    enabled: true
+
+ratings:
+  paths:
+  - "**.py"
+
+exclude_paths:
+- tests.py

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Code Climate](https://codeclimate.com/github/18F/cg-quotas-db/badges/gpa.svg)](https://codeclimate.com/github/18F/cg-quotas-db)
+
 # Quota Database App
 There are two distinct components that form the basis of this repository. At some point in the future we might split them out, for now they are going to stay together.
 


### PR DESCRIPTION
As part of the Fedramp effort, we are required to ensure static code analysis is run on all 18F developed code that is part of the cloud.gov platform:  https://github.com/18F/cg-product/issues/260

In support of this effort, this PR adds a basic code climate configuration and badge to the README.

**Also whomever is reviewing this PR please provide me with access to this repo, so I can configure the webhook required for automatically running code climate on each PR**