### PR TITLE
Update to 3.5.4

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.5.4


### PR DESCRIPTION
Python 3.5.2 no longer is allowed by our current shipping buildpacks